### PR TITLE
implement `nx-affected` utility

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,4 @@
+# Scripts
+
+This folder contains helpful scripts for various tasks. They intentionally do
+not use fancy features (e.g. object destructuring) to avoid any build steps.

--- a/scripts/nx-affected.js
+++ b/scripts/nx-affected.js
@@ -20,4 +20,9 @@ function isProjectAffected(projectName, baseCommit, headCommit) {
   return changedProjects.includes(projectName);
 }
 
+const args = process.argv.slice(2);
+if (args.length > 0) {
+  console.log(isProjectAffected(...args));
+}
+
 module.exports = isProjectAffected;

--- a/scripts/nx-affected.js
+++ b/scripts/nx-affected.js
@@ -1,0 +1,23 @@
+const execSync = require("child_process").execSync;
+
+/**
+ * Tests whether a NX project (app or lib) has been affected.
+ *
+ * @param {string} projectName
+ * @param {string} baseCommit
+ *
+ * @returns a boolean indicating whether this project has been affected.
+ */
+function isProjectAffected(projectName, baseCommit, headCommit) {
+  headCommit = headCommit ? headCommit : "HEAD";
+  let getAffected = baseCommit
+    ? `nx print-affected --base=${baseCommit} --head=${headCommit}`
+    : `nx print-affected`;
+
+  const output = execSync(getAffected).toString();
+  const changedProjects = JSON.parse(output).projects;
+
+  return changedProjects.includes(projectName);
+}
+
+module.exports = isProjectAffected;

--- a/scripts/nx-affected.js
+++ b/scripts/nx-affected.js
@@ -1,10 +1,21 @@
+/**
+ * Utility to check an nx project has been affected.
+ *
+ * This utility can be imported as a function or invoked directly via this js
+ * file:
+ * `node ./scripts/nx-affected.js [project-name] <base-commit> <head-commit>`
+ */
+
 const execSync = require("child_process").execSync;
 
 /**
  * Tests whether a NX project (app or lib) has been affected.
  *
- * @param {string} projectName
- * @param {string} baseCommit
+ * @param {string} projectName one of the project names in this nx workspace
+ * @param {string} baseCommit optional commit hash. If not provided, default to
+ *    the one chosen by the nx cli.
+ * @param {string} headCommit optional commit hash. If not provided, default to
+ *    the HEAD commit.
  *
  * @returns a boolean indicating whether this project has been affected.
  */

--- a/scripts/nx-affected.spec.js
+++ b/scripts/nx-affected.spec.js
@@ -2,10 +2,11 @@
  * Simple test file that tests nx-affected.js.
  *
  * This test file is not discoverable by the nx test runner. To test, run:
- * `node nx-affected.spec.js`
+ * `node nx-affected.spec.js` from the project root.
  */
 
 const isProjectAffected = require("./nx-affected");
+const execSync = require("child_process").execSync;
 
 const HEAD_COMMIT = "b5689e7c89873b3a74a5129fd087c4fb5e10a6d8";
 
@@ -29,10 +30,20 @@ function testReturnFalseForNonexistentProject() {
   assertTrue(!isProjectAffected("bogus-project", null, HEAD_COMMIT));
 }
 
+function testCanRunWithCommandLineArgs() {
+  const OLD_COMMIT = "c70077323ee2d57e8f0826d49fef2fc467562543";
+
+  const command = `node ./scripts/nx-affected.js todo-app ${OLD_COMMIT} ${HEAD_COMMIT}`;
+  const output = execSync(command).toString().trim();
+
+  assertTrue(output == "true");
+}
+
 function test() {
   testReturnTrueIfProjectChanged();
   testReturnFalseIfProjectDidNotChange();
   testReturnFalseForNonexistentProject();
+  testCanRunWithCommandLineArgs();
 }
 
 test();

--- a/scripts/nx-affected.spec.js
+++ b/scripts/nx-affected.spec.js
@@ -1,0 +1,38 @@
+/**
+ * Simple test file that tests nx-affected.js.
+ *
+ * This test file is not discoverable by the nx test runner. To test, run:
+ * `node nx-affected.spec.js`
+ */
+
+const isProjectAffected = require("./nx-affected");
+
+const HEAD_COMMIT = "b5689e7c89873b3a74a5129fd087c4fb5e10a6d8";
+
+function assertTrue(value) {
+  if (value !== true) {
+    throw new Error(`Expected 'true', got ${value}`);
+  }
+}
+
+function testReturnTrueIfProjectChanged() {
+  const OLD_COMMIT = "c70077323ee2d57e8f0826d49fef2fc467562543";
+  assertTrue(isProjectAffected("todo-app", OLD_COMMIT, HEAD_COMMIT));
+}
+
+function testReturnFalseIfProjectDidNotChange() {
+  const OLD_COMMIT = "b5689e7c89873b3a74a5129fd087c4fb5e10a6d8";
+  assertTrue(!isProjectAffected("todo-app", OLD_COMMIT, HEAD_COMMIT));
+}
+
+function testReturnFalseForNonexistentProject() {
+  assertTrue(!isProjectAffected("bogus-project", null, HEAD_COMMIT));
+}
+
+function test() {
+  testReturnTrueIfProjectChanged();
+  testReturnFalseIfProjectDidNotChange();
+  testReturnFalseForNonexistentProject();
+}
+
+test();


### PR DESCRIPTION
This helps facilitate checking whether a project has been affected in the terminal.

`nx print-affected` is not really friendly for terminal applications; its output is too verbose for convenient bash processing.